### PR TITLE
Fix compatible issue in php-7.1 Travis build

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -24,7 +24,7 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
      *
      * @return string
      */
-    protected function getServiceProviderClass($app): string
+    protected function getServiceProviderClass($app)
     {
         return \BrianFaust\TaxCalculator\TaxCalculatorServiceProvider::class;
     }


### PR DESCRIPTION
# Changed log

- fix the ```php-7.1``` test in Travis build because of the compatible issue.